### PR TITLE
Deployment file for Terrarium v.0.0.23

### DIFF
--- a/charts/terrarium/Chart.yaml
+++ b/charts/terrarium/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.18"
+appVersion: "0.0.23"

--- a/charts/terrarium/values.yaml
+++ b/charts/terrarium/values.yaml
@@ -5,7 +5,7 @@ modules_api_v1_service:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.18
+    tag: v0.0.23
     pullPolicy: Always
 browse_service:
   ingress:
@@ -13,35 +13,35 @@ browse_service:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.18
+    tag: v0.0.23
     pullPolicy: Always
 gateway:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.18
+    tag: v0.0.23
     pullPolicy: Always
 registrar:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.18
+    tag: v0.0.23
     pullPolicy: Always
 dependencyManager:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.18
+    tag: v0.0.23
     pullPolicy: Always
 versionManager:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.18
+    tag: v0.0.23
     pullPolicy: Always
 storage:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.18
+    tag: v0.0.23
     pullPolicy: Always


### PR DESCRIPTION
New deployment file for Terrarium v.0.0.23 .

- Terrarium [v.0.0.23](https://github.com/terrariumcloud/terrarium/releases/tag/v0.0.23) is deployed to a backup instance/green environment.
- Terrarium [v0.0.18](https://github.com/terrariumcloud/terrarium/releases/tag/v0.0.18) is the last version deployed to a primary instance.