### PR TITLE
Upgrade terrarium to 0.0.53

### DIFF
--- a/charts/terrarium/Chart.yaml
+++ b/charts/terrarium/Chart.yaml
@@ -19,10 +19,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.15
+version: 0.0.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.49"
+appVersion: "0.0.53"

--- a/charts/terrarium/values.yaml
+++ b/charts/terrarium/values.yaml
@@ -5,7 +5,7 @@ modules_api_v1_service:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.49
+    tag: v0.0.53
     pullPolicy: Always
 browse_service:
   ingress:
@@ -13,37 +13,37 @@ browse_service:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.49
+    tag: v0.0.53
     pullPolicy: Always
 gateway:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.49
+    tag: v0.0.53
     pullPolicy: Always
 registrar:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.49
+    tag: v0.0.53
     pullPolicy: Always
 dependencyManager:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.49
+    tag: v0.0.53
     pullPolicy: Always
 versionManager:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.49
+    tag: v0.0.53
     pullPolicy: Always
 storage:
   replicas: 1
   image:
     repository: ghcr.io/terrariumcloud/terrarium
-    tag: v0.0.49
+    tag: v0.0.53
     pullPolicy: Always
 otelTraceEndpoint: "satellite-lightstep.infra.svc.cluster.local:8184"
 grpcDebug: "info"


### PR DESCRIPTION
Terrarium Release: https://github.com/terrariumcloud/terrarium/releases/tag/v0.0.53

- [Release Service Scaffolding](https://github.com/terrariumcloud/terrarium/pull/37)
- [Maturity field appended to Browse API Response](https://github.com/terrariumcloud/terrarium/pull/35)
- [Golang Base Image update to 1.21](https://github.com/terrariumcloud/terrarium/pull/34)
- https://github.com/terrariumcloud/terrarium/pull/33
